### PR TITLE
Deserialize player fix

### DIFF
--- a/MarrowVale.Business.Entities/Entities/Npc.cs
+++ b/MarrowVale.Business.Entities/Entities/Npc.cs
@@ -17,7 +17,7 @@ namespace MarrowVale.Business.Entities.Entities
         public string Name { get; set; }
         public string Description { get; set; }
         public int CurrentHealth { get; set; }
-        public int MaxHealth { get; set; }
+        public int MaxHealth { get; }
         public int BaseDamage { get; }
 
         public IList<Ability> Abilities { get; }

--- a/MarrowVale.Business.Entities/Entities/Player.cs
+++ b/MarrowVale.Business.Entities/Entities/Player.cs
@@ -9,18 +9,19 @@ namespace MarrowVale.Business.Entities.Entities
 {
     public class Player
     {
-        public Player() { }
-        public Player(PlayerDto player)
+        public Player() {
+            Abilities = new List<Ability>();
+            Spellbook = new List<Spell>();
+            Inventory = new Inventory();
+        }
+
+        public Player(PlayerDto player) : this()
         {
             Race = player.Race;
             Gender = player.Gender;
             Class = player.Class;
             Name = player.Name;
-
-            Abilities = new List<Ability>();
-            Spellbook = new List<Spell>();
-            Inventory = new Inventory();
-
+            
             if (Class == ClassEnum.Mage)
             {               
                 MaxHealth = 15;
@@ -36,6 +37,15 @@ namespace MarrowVale.Business.Entities.Entities
                 MaxHealth = 25;
                 CurrentHealth = 25;
             }
+        }
+
+        [JsonConstructor]
+        private Player(RaceEnum Race, string Gender, ClassEnum Class, string Name)
+        {
+            this.Race = Race;
+            this.Gender = Gender;
+            this.Class = Class;
+            this.Name = Name;
         }
 
         public string Name { get; set; }

--- a/MarrowVale.Business.Entities/Entities/Spell.cs
+++ b/MarrowVale.Business.Entities/Entities/Spell.cs
@@ -1,6 +1,4 @@
 ﻿using MarrowVale.Business.Entities.Enums;
-using Newtonsoft.Json;
-using System.ComponentModel;
 
 namespace MarrowVale.Business.Entities.Entities
 {
@@ -11,7 +9,7 @@ namespace MarrowVale.Business.Entities.Entities
         public string Name { get; }
         public string Description { get; }
         public int Damage { get; private set; }
-        public SpellElementEnum Element { get; protected set; }
+        public SpellElementEnum Element { get; }
 
         public int NumberOfUses { get; set; }
         public int AvailableNumberOfUses { get; set; }

--- a/MarrowVale.Business.Entities/Entities/Weapon.cs
+++ b/MarrowVale.Business.Entities/Entities/Weapon.cs
@@ -1,14 +1,13 @@
 ﻿using MarrowVale.Business.Entities.Enums;
-using Newtonsoft.Json;
-using System.ComponentModel;
 
 namespace MarrowVale.Business.Entities.Entities
 {
     public class Weapon : IItem
     {
-        public Weapon(int worth)
+        public Weapon(int BaseWorth, WeaponTypeEnum Type)
         {
-            BaseWorth = worth;
+            this.BaseWorth = BaseWorth;
+            this.Type = Type;
         }
 
         public int Range { get; set; }
@@ -17,7 +16,7 @@ namespace MarrowVale.Business.Entities.Entities
         public string Name { get; set; }
         public string Description { get; set; }
         public bool IsBroken { get; set; }
-        public WeaponTypeEnum Type { get; private set; }
+        public WeaponTypeEnum Type { get; }
         public bool IsVisible { get; set; }
         public int BaseWorth { get; set; }
     }

--- a/MarrowVale.Business/Services/CharacterService.cs
+++ b/MarrowVale.Business/Services/CharacterService.cs
@@ -228,7 +228,7 @@ namespace MarrowVale.Business.Services
             }
         }
 
-        private void pickClass(PlayerDto playerDto)
+        private void printClassDescriptions()
         {
             var characterClass = _drawingRepository.GetCharacterCreationStateArt(PlayerCreationStateEnum.Class);
 
@@ -252,6 +252,11 @@ namespace MarrowVale.Business.Services
             _printService.Print(warriorDescription);
             _printService.Print(rangerDescription, 10);
             _printService.Print(mageDescription, 10);
+        }
+
+        private void pickClass(PlayerDto playerDto)
+        {
+            printClassDescriptions();
 
             _printService.Print("Which class do you want your new character to be?  Warrior | Ranger | Mage", 10);
 
@@ -259,87 +264,21 @@ namespace MarrowVale.Business.Services
 
             if (charClass == "Warrior")
             {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Class = ClassEnum.Warrior;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        repickClass(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
+                verifyClassPick(playerDto, charClass, ClassEnum.Warrior);
             }
             else if (charClass == "Ranger")
             {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Class = ClassEnum.Ranger;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        repickClass(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
+                verifyClassPick(playerDto, charClass, ClassEnum.Ranger);
             }
             else if (charClass == "Mage")
             {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Class = ClassEnum.Mage;          
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        repickClass(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
+                verifyClassPick(playerDto, charClass, ClassEnum.Mage);
             }
             else
             {
                 _printService.Print("You must type the name of the class that you wish for your character.");
                 Thread.Sleep(5000);
-                repickClass(playerDto);
+                pickClass(playerDto);
             }
 
         }
@@ -389,121 +328,32 @@ namespace MarrowVale.Business.Services
                 pickGender(playerDto);
             }
         }
-
-        private void repickClass(PlayerDto playerDto)
+        
+        private void verifyClassPick(PlayerDto playerDto, string charClass, ClassEnum pickedClass)
         {
-            var characterClass = _drawingRepository.GetCharacterCreationStateArt(PlayerCreationStateEnum.Class);
+            var choiceMade = false;
 
-            _printService.ClearConsole();
-
-            _drawingService.PrintArtCentered(characterClass);
-
-            var warriorDescription = "Only ever knowing violence, the warrior's purpose is to protect people from ever experiencing that pain themselves.\n" +
-                                     "Unmatched with blades and axes, the warrior likes to get up close and personal during combat. They rely on their\n" +
-                                     "strength above all else to solve their problems.";
-
-            var rangerDescription = "Born of the forest, a ranger is one with their surroundings. Heightened senses allow the ranger to detect changes in\n" +
-                                    "their environment that others may not realize. The ranger excels with a bow. The ranger's soft footsteps developed over\n" +
-                                    "years of hunting and tracking are a great tool for getting into places undetected.";
-
-            var mageDescription = "The mage is born with a connection to the Elemental Plane. Years of study and patience has resulted in an understanding\n" +
-                                  "of the magical world that others can't even begin to realize. Typically, the mage prefers non-physical means of solving\n" +
-                                  "problems, and with their high intelligence and their knowledge of the magical arts, there are few problems that a mage\n" +
-                                  "cannot solve.";
-
-            _printService.Print(warriorDescription);
-            _printService.Print(rangerDescription);
-            _printService.Print(mageDescription);
-
-            _printService.Print("Which class do you want your new character to be?  Warrior | Ranger | Mage");
-
-            var charClass = _globalItemsProvider.UpperFirstChar(_printService.ReadInput());
-
-            if (charClass == "Warrior")
+            while (!choiceMade)
             {
-                var choiceMade = false;
+                _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
 
-                while (!choiceMade)
+                var choice = _printService.ReadInput();
+
+                if (choice.ToUpper() == "YES")
                 {
-                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Class = ClassEnum.Warrior;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        repickClass(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
+                    playerDto.Class = pickedClass;
+                    choiceMade = true;
+                }
+                else if (choice.ToUpper() == "NO")
+                {
+                    pickClass(playerDto);
+                    choiceMade = true;
+                }
+                else
+                {
+                    _printService.Print("You must type yes or no.");
                 }
             }
-            else if (charClass == "Ranger")
-            {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Class = ClassEnum.Ranger;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        repickClass(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
-            }
-            else if (charClass == "Mage")
-            {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Class = ClassEnum.Mage;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        repickClass(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
-            }
-            else
-            {
-                _printService.Print("You must type the name of the class that you wish for your character.");
-                Thread.Sleep(5000);
-                repickClass(playerDto);
-            }
-
         }
 
         private void loadNewInventory(Class startingClass, Player player)

--- a/MarrowVale.Business/Services/CharacterService.cs
+++ b/MarrowVale.Business/Services/CharacterService.cs
@@ -1,5 +1,4 @@
 ﻿using MarrowVale.Business.Contracts;
-using MarrowVale.Business.Entities;
 using MarrowVale.Business.Entities.Dtos;
 using MarrowVale.Business.Entities.Entities;
 using MarrowVale.Business.Entities.Enums;
@@ -7,7 +6,6 @@ using MarrowVale.Common.Contracts;
 using MarrowVale.Data.Contracts;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Linq;
 using System.Threading;
 
 namespace MarrowVale.Business.Services

--- a/MarrowVale.Business/Services/CharacterService.cs
+++ b/MarrowVale.Business/Services/CharacterService.cs
@@ -139,74 +139,24 @@ namespace MarrowVale.Business.Services
 
             var race = _globalItemsProvider.UpperFirstChar(_printService.ReadInput());
 
-            if (race == Enum.GetName(typeof(RaceEnum), 0))
+            verifyRacePick(playerDto, race);
+        }
+
+        private void verifyRacePick(PlayerDto playerDto, string race)
+        {
+            if(Enum.TryParse<RaceEnum>(race, out var result))
             {
                 var choiceMade = false;
 
                 while (!choiceMade)
                 {
-                    //chose human
                     _printService.Print($"Are you sure you want to be a {race}?  yes | no");
 
                     var choice = _printService.ReadInput();
 
                     if (choice.ToUpper() == "YES")
                     {
-                        playerDto.Race = RaceEnum.Human;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        pickRace(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
-            }
-            else if (race == Enum.GetName(typeof(RaceEnum), 1))
-            {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    //chose elf
-                    _printService.Print($"Are you sure you want to be a {race}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Race = RaceEnum.Elf;
-                        choiceMade = true;
-                    }
-                    else if (choice.ToUpper() == "NO")
-                    {
-                        pickRace(playerDto);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type yes or no.");
-                    }
-                }
-            }
-            else if (race == Enum.GetName(typeof(RaceEnum), 2))
-            {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    //chose dwarf
-                    _printService.Print($"Are you sure you want to be a {race}?  yes | no");
-
-                    var choice = _printService.ReadInput();
-
-                    if (choice.ToUpper() == "YES")
-                    {
-                        playerDto.Race = RaceEnum.Dwarf;
+                        playerDto.Race = result;
                         choiceMade = true;
                     }
                     else if (choice.ToUpper() == "NO")
@@ -225,6 +175,52 @@ namespace MarrowVale.Business.Services
                 _printService.Print("You must type Human, Elf, or Dwarf.");
                 Thread.Sleep(3);
                 pickRace(playerDto);
+            }
+        }
+
+        private void pickGender(PlayerDto playerDto)
+        {
+            var characterGender = _drawingRepository.GetCharacterCreationStateArt(PlayerCreationStateEnum.Gender);
+
+            _printService.ClearConsole();
+
+            _drawingService.PrintArtCentered(characterGender);
+
+            _printService.Print("Do you want your character to be a male or a female?");
+
+            var gender = _printService.ReadInput();
+
+            if (gender.ToUpper() == "MALE" || gender.ToUpper() == "FEMALE")
+            {
+                var choiceMade = false;
+
+                while (!choiceMade)
+                {
+                    _printService.Print($"Are you sure you want your character to be {gender}?  yes | no");
+
+                    var decision = _printService.ReadInput();
+
+                    if (decision.ToUpper() == "NO")
+                    {
+                        pickGender(playerDto);
+                        choiceMade = true;
+                    }
+                    else if (decision.ToUpper() == "YES")
+                    {
+                        playerDto.Gender = _globalItemsProvider.UpperFirstChar(gender);
+                        choiceMade = true;
+                    }
+                    else
+                    {
+                        _printService.Print("You must type in yes or no");
+                    }
+                }
+            }
+            else
+            {
+                _printService.Print("You must type in male or female.");
+                Thread.Sleep(3);
+                pickGender(playerDto);
             }
         }
 
@@ -282,53 +278,7 @@ namespace MarrowVale.Business.Services
             }
 
         }
-
-        private void pickGender(PlayerDto playerDto)
-        {
-            var characterGender = _drawingRepository.GetCharacterCreationStateArt(PlayerCreationStateEnum.Gender);
-
-            _printService.ClearConsole();
-
-            _drawingService.PrintArtCentered(characterGender);
-
-            _printService.Print("Do you want your character to be a male or a female?");
-
-            var gender = _printService.ReadInput();
-
-            if (gender.ToUpper() == "MALE" || gender.ToUpper() == "FEMALE")
-            {
-                var choiceMade = false;
-
-                while (!choiceMade)
-                {
-                    _printService.Print($"Are you sure you want your character to be {gender}?  yes | no");
-
-                    var decision = _printService.ReadInput();
-
-                    if (decision.ToUpper() == "NO")
-                    {
-                        pickGender(playerDto);
-                        choiceMade = true;
-                    }
-                    else if (decision.ToUpper() == "YES")
-                    {
-                        playerDto.Gender = _globalItemsProvider.UpperFirstChar(gender);
-                        choiceMade = true;
-                    }
-                    else
-                    {
-                        _printService.Print("You must type in yes or no");
-                    }
-                }
-            }
-            else
-            {
-                _printService.Print("You must type in male or female.");
-                Thread.Sleep(3);
-                pickGender(playerDto);
-            }
-        }
-        
+                
         private void verifyClassPick(PlayerDto playerDto, string charClass, ClassEnum pickedClass)
         {
             var choiceMade = false;

--- a/MarrowVale.Business/Services/CharacterService.cs
+++ b/MarrowVale.Business/Services/CharacterService.cs
@@ -54,7 +54,7 @@ namespace MarrowVale.Business.Services
 
             _playerRepository.AddPlayer(player);
                        
-            Console.WriteLine($"\nName: {playerDto.Name}");
+            Console.WriteLine($"{Environment.NewLine}Name: {playerDto.Name}");
             Console.WriteLine($"Gender: {playerDto.Gender}");
             Console.WriteLine($"Race: {playerDto.Race}");
             Console.WriteLine($"Class: {playerDto.Class}");

--- a/MarrowVale.Business/Services/CharacterService.cs
+++ b/MarrowVale.Business/Services/CharacterService.cs
@@ -258,51 +258,41 @@ namespace MarrowVale.Business.Services
 
             var charClass = _globalItemsProvider.UpperFirstChar(_printService.ReadInput());
 
-            if (charClass == "Warrior")
-            {
-                verifyClassPick(playerDto, charClass, ClassEnum.Warrior);
-            }
-            else if (charClass == "Ranger")
-            {
-                verifyClassPick(playerDto, charClass, ClassEnum.Ranger);
-            }
-            else if (charClass == "Mage")
-            {
-                verifyClassPick(playerDto, charClass, ClassEnum.Mage);
+            verifyClassPick(playerDto, charClass);
+        }
+                
+        private void verifyClassPick(PlayerDto playerDto, string charClass)
+        {
+            if(Enum.TryParse<ClassEnum>(charClass, out var result)){
+                var choiceMade = false;
+
+                while (!choiceMade)
+                {
+                    _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
+
+                    var choice = _printService.ReadInput();
+
+                    if (choice.ToUpper() == "YES")
+                    {
+                        playerDto.Class = result;
+                        choiceMade = true;
+                    }
+                    else if (choice.ToUpper() == "NO")
+                    {
+                        pickClass(playerDto);
+                        choiceMade = true;
+                    }
+                    else
+                    {
+                        _printService.Print("You must type yes or no.");
+                    }
+                }
             }
             else
             {
                 _printService.Print("You must type the name of the class that you wish for your character.");
                 Thread.Sleep(5000);
                 pickClass(playerDto);
-            }
-
-        }
-                
-        private void verifyClassPick(PlayerDto playerDto, string charClass, ClassEnum pickedClass)
-        {
-            var choiceMade = false;
-
-            while (!choiceMade)
-            {
-                _printService.Print($"Are you sure you want to be a {charClass}?  yes | no");
-
-                var choice = _printService.ReadInput();
-
-                if (choice.ToUpper() == "YES")
-                {
-                    playerDto.Class = pickedClass;
-                    choiceMade = true;
-                }
-                else if (choice.ToUpper() == "NO")
-                {
-                    pickClass(playerDto);
-                    choiceMade = true;
-                }
-                else
-                {
-                    _printService.Print("You must type yes or no.");
-                }
             }
         }
 

--- a/MarrowVale.Business/Services/CombatService.cs
+++ b/MarrowVale.Business/Services/CombatService.cs
@@ -1,8 +1,5 @@
 ﻿using MarrowVale.Business.Contracts;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MarrowVale.Business.Services
 {

--- a/MarrowVale.Business/Services/DrawingService.cs
+++ b/MarrowVale.Business/Services/DrawingService.cs
@@ -18,27 +18,27 @@ namespace MarrowVale.Business.Services
         public void PrintArtCentered(string[] art)
         {
             Console.WindowWidth = _globalItemsProvider.WindowWidth;
-            Console.WriteLine("\n");
-            foreach (string line in art)
+            Console.WriteLine(Environment.NewLine);
+            foreach (var line in art)
             {
                 Console.SetCursorPosition((Console.WindowWidth - line.Length) / 2, Console.CursorTop);
                 Console.WriteLine(line);
             }
 
-            Console.WriteLine("\n\n");
+            Console.WriteLine($"{Environment.NewLine}{Environment.NewLine}");
         }
 
         public void PrintArt(string[] art)
         {
             Console.WindowWidth = _globalItemsProvider.WindowWidth;
-            Console.WriteLine("\n");
-            foreach (string line in art)
+            Console.WriteLine(Environment.NewLine);
+            foreach (var line in art)
             {
                 Console.SetCursorPosition((Console.WindowWidth - line.Length) / 2, Console.CursorTop);
                 Console.WriteLine(line);
             }
 
-            Console.WriteLine("\n\n");
+            Console.WriteLine($"{Environment.NewLine}{Environment.NewLine}");
         }
     }
 }

--- a/MarrowVale.Common/Providers/GlobalItemsProvider.cs
+++ b/MarrowVale.Common/Providers/GlobalItemsProvider.cs
@@ -1,8 +1,5 @@
 ﻿using MarrowVale.Common.Contracts;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace MarrowVale.Common.Providers
 {
@@ -19,6 +16,11 @@ namespace MarrowVale.Common.Providers
 
         public string UpperFirstChar(string text)
         {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
             return char.ToUpper(text[0]) + ((text.Length > 1) ? text.Substring(1).ToLower() : string.Empty);
         }
     }

--- a/MarrowVale.Data/Repositories/PlayerRepository.cs
+++ b/MarrowVale.Data/Repositories/PlayerRepository.cs
@@ -3,7 +3,6 @@ using MarrowVale.Common.Contracts;
 using MarrowVale.Data.Contracts;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/MarrowVale.Data/Repositories/PlayerRepository.cs
+++ b/MarrowVale.Data/Repositories/PlayerRepository.cs
@@ -31,7 +31,8 @@ namespace MarrowVale.Data.Repositories
         {
             var settings = new JsonSerializerSettings()
             {
-                TypeNameHandling = TypeNameHandling.All
+                TypeNameHandling = TypeNameHandling.All,
+                ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
             };
 
             var playerList = JsonConvert.DeserializeObject<List<Player>>(PlayerFile, settings);


### PR DESCRIPTION
Change the json.net deserialize method to use constructor instead of the default property one.
This was to facilitate the private and readonly properties from getting set properly.

Reduced the complexity of the character creation methods. RepickClass and PickClass we the same and condensed the method down by using a method to verify the pick. Reduced the size of RacePick by taking advantage of casting string to enum with tryparse.